### PR TITLE
Add flexbox-react

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -390,6 +390,7 @@ It will be added once the community has approved it.
  - [react-masonry-component](https://github.com/eiriklv/react-masonry-component) - A React.js component for using @desandro&#39;s Masonry.
  - [react-flexbox-grid](https://github.com/roylee0704/react-flexbox-grid) - A set of React components implementing flexboxgrid with the power of CSS Modules.
  - [react-stonecutter](https://github.com/dantrain/react-stonecutter) - Animated grid layout component for React.
+ - [flexbox-react](https://github.com/nachoaIvarez/flexbox-react) - Unopinionated, standard compliant flexbox component. No propietary API, just flexbox.
 
 
 # UI Animation


### PR DESCRIPTION
I couldn't find a spec compliant flexbox component/s for react, so I created `flexbox-react`. It's documented, it's simple and it works, so I guess it might have a place here 😄

Sadly, the `react-flexbox` name was taken by [this project](https://www.npmjs.com/package/react-flexbox) which doesn't respect the flexbox standard. Note this project is already in the list.

Thanks!