### PR TITLE
Update link of depressiated component

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -269,7 +269,7 @@
 *Ways to navigate views*
 
  - [react-scroll](https://github.com/fisshy/react-scroll) - React scroll component.
- - [react-swipe-views](https://github.com/oliviertassinari/react-swipeable-views) - A React Component for binded Tabs and Swipeable Views.
+ - [react-swipeable-views](https://github.com/oliviertassinari/react-swipeable-views) - A React Component for binded Tabs and Swipeable Views.
 
 
 ### Custom Scrollbar

--- a/readme.md
+++ b/readme.md
@@ -269,7 +269,7 @@
 *Ways to navigate views*
 
  - [react-scroll](https://github.com/fisshy/react-scroll) - React scroll component.
- - [react-swipe-views](https://github.com/damusnet/react-swipe-views) - A React Component for binded Tabs and Swipeable Views.
+ - [react-swipe-views](https://github.com/oliviertassinari/react-swipeable-views) - A React Component for binded Tabs and Swipeable Views.
 
 
 ### Custom Scrollbar


### PR DESCRIPTION
I clicked on the original repo and the README said it stopped working after React 0.13. It linked to another repo.