### PR TITLE
Rename admin-on-rest to react-admin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -662,8 +662,7 @@
 
  - [react-desktop](https://github.com/gabrielbull/react-desktop) - React UI Components for macOS Sierra and Windows 10.
  - [aframe-react](https://github.com/ngokevin/aframe-react) - Build virtual reality experiences with A-Frame and React.
- - [admin-on-rest](https://github.com/marmelab/admin-on-rest) - A frontend framework for building admin SPAs on top of REST services, using React and Material Design.
-
+ - [react-admin](https://github.com/marmelab/react-admin) - Build admin user experiences on top of REST and GraphQL services, using React, Redux, and Material Design.
 
 ## UI Utilites
 


### PR DESCRIPTION
Admin-on-rest was renamed to react-admin a couple months ago.
