### PR TITLE
#57. Add gigatables-react to Table/data-grid section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,7 @@
  - [reactabular](https://github.com/reactabular/reactabular) - Spectacular tables for React.
  - [fixed-data-table](https://github.com/facebook/fixed-data-table) - A React table component designed to allow presenting thousands of rows of data.
  - [sematable](https://github.com/sematext/sematable) - Client side sorting, pagination, and text filter for redux/react based apps.
+ - [gigatables-react](https://github.com/GigaTables/reactables) - Sorting, pagination/infinite scroll, global/column search, ajax CRUD, keyboard controls, fixed header, 10 languages.
 
 
 ### Infinite Scroll


### PR DESCRIPTION
Adding component as asked in #57, thank you for an occasion.
[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/GigaTables/reactables/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/GigaTables/reactables/?branch=master)
[![Build Status](https://travis-ci.org/GigaTables/reactables.svg?branch=master)](https://travis-ci.org/GigaTables/reactables)
[![Code Coverage](https://codecov.io/gh/GigaTables/reactables/branch/master/graph/badge.svg)](https://codecov.io/gh/GigaTables/reactables)
[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)