### PR TITLE
Replace Reactabular with react-table

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Please review our [contributing guidelines](https://github.com/brillout/awesome-
 - [gigatables-react](https://github.com/GigaTables/reactables) - Sorting, pagination/infinite scroll, global/column search, AJAX CRUD, and more.
 - [griddle-react](https://github.com/GriddleGriddle/Griddle) - Simple Grid Component written in React.
 - [ka-table](https://github.com/komarovalexander/ka-table) - [demo](https://komarovalexander.github.io/ka-table/#/command-column) - Customizable MIT React table component with Sorting, Filtering, Grouping, Virtualization, Editing and many more.
-- [mui-datatables](https://github.com/gregnb/mui-datatables) - Advanced and Pretty Data Tables where everything is customisable.
+- [mui-datatables](https://github.com/gregnb/mui-datatables) - Responsive table component built on Material-UI, featuring search, pagination, sorting, styling, filtering, resizable + view/hide columns, export to CSV, printing, selectable or expandable rows.
 - [react-data-components](https://github.com/carlosrocha/react-data-components) - React components for sorting, filtering and pagination of data.
 - [react-data-grid](https://github.com/adazzle/react-data-grid) - Excel-like grid.
 - [react-pivot](https://github.com/davidguttman/react-pivot) - Data-grid component with pivot-table-like for data display, filtering, and exploration.
-- [reactabular](https://github.com/reactabular/reactabular) - Spectacular tables for React.
+- [react-table](https://github.com/tannerlinsley/react-table) - [demo](https://github.com/tannerlinsley/react-table/blob/master/docs/examples.md) - Hooks for building fast and extendable tables and datagrids
 - [rsuite-table](https://github.com/rsuite/rsuite-table) - [demo/docs](http://rsuite.github.io/rsuite-table/) - A table component that supports virtualized.
 - [sematable](https://github.com/sematext/sematable) - Client side sorting, pagination, and text filter for redux/react based apps.
 - [shineout](https://github.com/sheinsight/shineout) - [demo](https://shine.wiki/1.3.x/en/components/Table#heading-08-bigdata) - A comprehensive solution for complicated/big-data table.


### PR DESCRIPTION
Reactabular is no longer "Spectacular tables for React." and hasn't been maintained in 51 weeks.
react-table addresses the same need, and is much more popular and actively maintained.

Also replace the hyped description for mui-datatables with a more impartial and precise one.