### PR TITLE
Add react-headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ _Sketch input using Canvas or SVG_
 - [react-simple-chatbot](https://github.com/LucasBassetti/react-simple-chatbot) - [demo](https://github.com/anishagg17/PIzzaBuilder) - A simple chatbot component to create conversation chats.
 - [react-file-reader-input](https://github.com/ngokevin/react-file-reader-input) - File input component for control for file reading styling and abstraction.
 - [react-filter-control](https://github.com/komarovalexander/react-filter-control) - The React filterbuilder component for building the filter criteria in the UI.
+- [react-headings](https://github.com/alexnault/react-headings) - Auto-increment your HTML headings (h1, h2, etc.) for improved accessibility and SEO, no matter your component structure, while you keep full control of what's rendered.
 - [react-joyride](https://github.com/gilbarbara/react-joyride) - Create walkthroughs and guided tours for your ReactJS apps. Now with standalone tooltips!.
 - [react-json-tree](https://github.com/alexkuz/react-json-tree) - React JSON Viewer Component, Extracted from redux-devtools.
 - [react-resizable-and-movable](https://github.com/bokuweb/react-resizable-and-movable) - Resizable and movable component for React.
@@ -728,7 +729,6 @@ _Set meta tags, <title>, children of <head>_
 
 _Render an element at an arbitrary DOM node_
 
-- [react-gateway](https://github.com/cloudflare/react-gateway) - Render React DOM into a new context (aka "Portal").
 - [react-layer-stack](https://github.com/fckt/react-layer-stack) - Simple but ubiquitously powerful and agnostic layering system for React.
 - [react-portal](https://github.com/tajo/react-portal) - React component for transportation of modals, lightboxes, loading bars... to document.body.
 


### PR DESCRIPTION
Removed react-gateway since last commit dates back November 2017 and React has had built-in Portals for a while now. It looks abandoned (see [this issue](https://github.com/cloudflare/react-gateway/issues/46) and [this issue](https://github.com/cloudflare/react-gateway/issues/32)).