### PR TITLE
Resolves Deprecated Server Communication Components #289

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,10 +827,7 @@ _Component properties asynchronously fetched over the network_
 
 - [adrenaline](https://github.com/gyzerok/adrenaline) - Simple Relay alternative.
 - [apollo-client](https://github.com/apollostack/apollo-client) - A simple caching client for any GraphQL server and UI framework.
-- [cerebral-module-http](https://github.com/cerebral/cerebral-module-http) - HTTP module for Cerebral.
-- [react-apollo](https://github.com/apollostack/react-apollo) - React data container for the Apollo Client.
 - [react-relay](https://github.com/facebook/relay) - Relay is a JavaScript framework for building data-driven React applications.
-- [react-transmit](https://github.com/RickWong/react-transmit) - Relay-inspired library based on Promises instead of GraphQL.
 
 ### CSS / Style
 


### PR DESCRIPTION
https://github.com/apollographql/react-apollo is now provided by https://github.com/apollographql/apollo-client (already listed) according to the Project's readme.  - Removed obsolete URL, apollo client already listed and left as it is. 

https://github.com/RickWong/react-transmit is also archived and does not appear to have been updated in 5 years. - Removed 

Edit: https://github.com/cerebral-legacy/cerebral-module-http also appears to be replaced by https://github.com/cerebral/cerebral according to the former's readme. -  - Removed obsolete URL,cerebral already listed and it is left as it is .