### PR TITLE
add tagify

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,10 +485,10 @@ _Let the user select something (e.g. a tag) while typing_
 
 _Let the user add multiple tags in a single input_
 
-- [@pathofdev/react-tag-input](https://github.com/pathofdev/react-tag-input) - [demo & docs](https://pathof.dev/projects/react-tag-input) - Minimal tagging component with editable tags
 - [react-tag-input](https://github.com/prakhar1989/react-tags) - A fantastically simple tagging component for your React projects.
 - [react-tagsinput](https://github.com/olahol/react-tagsinput) - A simple react component for inputing tags.
 - [react-tokeninput](https://github.com/instructure-react/react-tokeninput) - Tokeninput component for React.
+- [tagify](https://github.com/yairEO/tagify) - [demo & docs](https://yaireo.github.io/tagify/) - Lightweight, efficient Tags input component.
 
 #### Autosize Input / Textarea
 


### PR DESCRIPTION
[@pathofdev/react-tag-input](https://github.com/pathofdev/react-tag-input) is no longer maintained (3 years since last release with unreviewed PRs).

[Tagify](https://github.com/yairEO/tagify) provides similar functionality and implements a lot of missing features, such as comma delimitation.