### PR TITLE
replace react-photo-gallery with react-photo-album

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ _Display images / photos_
 - [react-image-gallery](https://github.com/xiaolin/react-image-gallery) - Responsive image gallery, carousel, image slider react component.
 - [react-image-lightbox](https://github.com/fritz-c/react-image-lightbox) - React lightbox component.
 - [react-intense](https://github.com/brycedorn/react-intense) - A React component for viewing large images up close.
-- [react-photo-gallery](https://github.com/neptunian/react-photo-gallery) - Responsive React Photo Gallery.
+- [react-photo-album](https://github.com/igordanchenko/react-photo-album) - [demo](https://react-photo-album.com/examples) - [docs](https://react-photo-album.com/documentation) - Responsive React Photo Gallery.
 - [react-svg-pan-zoom](https://github.com/chrvadala/react-svg-pan-zoom) - A React component that adds pan and zoom features to SVG.
 - [react-particle-image](https://github.com/malerba118/react-particle-image) - [demo](https://malerba118.github.io/react-particle-image-demo/) - Render images as interactive particles.
 - [react-imgix](https://github.com/imgix/react-imgix) - Add fast, responsive images as an image, picture, or background!


### PR DESCRIPTION
[react-photo-gallery](https://github.com/neptunian/react-photo-gallery) is no longer maintained (no commits or merged PRs since 2019) and has multiple known issues with React 17+ and SSR (community-provided PRs addressing some of these issues haven't been reviewed or merged in more than 2 years).

[react-photo-album](https://github.com/igordanchenko/react-photo-album) is a complete rewrite covering 100% of the original library features.