### PR TITLE
Added yairEO/ui-switch  [Toggle componnet]

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,8 @@ _Autosuggest / autocomplete / typeahead_
 - [@anatoliygatt/heart-switch](https://github.com/anatoliygatt/heart-switch) - [demo](https://codesandbox.io/s/demo-for-anatoliygatt-heart-switch-cds5p) - A fully themeable and accessible heart-shaped toggle switch component.
 - [react-ios-switch](https://github.com/clari/react-ios-switch) - React switch component.
 - [react-toggle](https://github.com/instructure-react/react-toggle) - An elegant, accessible toggle component for React. Also a glorified checkbox.
-- [react-triple-toggle](https://github.com/geobde/react-triple-toggle) - ⚛️ React multi toggle component.
+- [react-triple-toggle](https://github.com/geobde/react-triple-toggle) - React multi toggle component.
+- [ui-switch](https://github.com/yairEO/ui-switch) - The most complete *Toggle* component 
 
 #### Slider
 


### PR DESCRIPTION
Added `yairEO/ui-switch` and removed the icon above which is only there to attract attention

Your list is only for React components, there is absolutely no need to add icons/emojis of React as it is obvious.
Also the word "React" itself in the names of the components is redundant 