### PR TITLE
Add react-mobile-cropper

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,6 @@ _Sketch input using Canvas or SVG_
 - [react-filter-control](https://github.com/komarovalexander/react-filter-control) - The React filterbuilder component for building the filter criteria in the UI.
 - [react-headings](https://github.com/alexnault/react-headings) - Auto-increment your HTML headings (h1, h2, etc.) for improved accessibility and SEO, no matter your component structure, while you keep full control of what's rendered.
 - [react-joyride](https://github.com/gilbarbara/react-joyride) - Create walkthroughs and guided tours for your ReactJS apps. Now with standalone tooltips!.
-- [react-json-tree](https://github.com/alexkuz/react-json-tree) - React JSON Viewer Component, Extracted from redux-devtools.
 - [react-mouse-select](https://github.com/andreizanik/react-mouse-select) - [Demo](https://andreizanik.github.io/react-mouse-select/) A component that allows selecting DOM elements by moving the mouse
 - [react-resizable-and-movable](https://github.com/bokuweb/react-resizable-and-movable) - Resizable and movable component for React.
 - [react-resizable-box](https://github.com/bokuweb/react-resizable-box) - Resizable component for React. #reactjs.
@@ -565,7 +564,8 @@ _Image manipulation_
 - [react-easy-crop](https://github.com/ricardo-ch/react-easy-crop) - Component to crop/rotate images/videos with easy interactions. Touch friendly.
 - [react-image-crop](https://github.com/DominicTobias/react-image-crop) - A responsive image cropping tool for React.
 - [react-image-cropper](https://github.com/jerryshew/react-image-cropper) - Image cropper.
-- [react-advanced-cropper](https://github.com/Norserium/react-advanced-cropper) - A react cropper library to create the cropper exactly suited for your website design.
+- [react-advanced-cropper](https://github.com/advanced-cropper/react-advanced-cropper) - A react cropper library to create the cropper exactly suited for your website design.
+- [react-mobile-cropper](https://github.com/advanced-cropper/react-mobile-cropper) - A ready-to-use image cropping library highly inspirited by popular Android croppers. Based on `react-advanced-cropper`.
 
 #### Form Component Collections
 


### PR DESCRIPTION
This library is based on [`react-advanced-cropper`](https://github.com/advanced-cropper/react-advanced-cropper). Unlike the original library this library doesn't focus on flexibility, it's ready-to-use solution with the specific behavior and the interface.

[Documentation](https://github.com/advanced-cropper/react-mobile-cropper) / [Sandbox](https://codesandbox.io/s/react-mobile-cropper-c1bz2)

According to the rules, I've removed the link to [`react-json-tree`](https://github.com/alexkuz/react-json-tree), because it's archived now and the repository content moved to `redux-devtools` monorepository that is already in this list.