### PR TITLE
replace react-image-lightbox with yet-another-react-lightbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ _Display images / photos_
 - [lightGallery](https://github.com/sachinchoolur/lightGallery) - [demo](https://www.lightgalleryjs.com/) - [docs](https://www.lightgalleryjs.com/docs/react/) - Full-featured lightbox gallery component.
 - [react-compare-image](https://github.com/junkboy0315/react-compare-image) - [demo](https://react-compare-image.yuuniworks.com/) - React component to compare two images using a slider.
 - [react-image-gallery](https://github.com/xiaolin/react-image-gallery) - Responsive image gallery, carousel, image slider react component.
-- [react-image-lightbox](https://github.com/fritz-c/react-image-lightbox) - React lightbox component.
+- [yet-another-react-lightbox](https://github.com/igordanchenko/yet-another-react-lightbox) - [demo](https://yet-another-react-lightbox.com/examples) - [docs](https://yet-another-react-lightbox.com/documentation) - React lightbox component.
 - [react-intense](https://github.com/brycedorn/react-intense) - A React component for viewing large images up close.
 - [react-photo-album](https://github.com/igordanchenko/react-photo-album) - [demo](https://react-photo-album.com/examples) - [docs](https://react-photo-album.com/documentation) - Responsive React Photo Gallery.
 - [react-svg-pan-zoom](https://github.com/chrvadala/react-svg-pan-zoom) - A React component that adds pan and zoom features to SVG.


### PR DESCRIPTION
[react-image-lightbox](https://github.com/frontend-collective/react-image-lightbox) doesn't appear to be maintained anymore (no commits since mid 2021)

[yet-another-react-lightbox](https://github.com/igordanchenko/yet-another-react-lightbox) is a modern lightbox component for React.