### PR TITLE
Add a Form Logic:hook-form-react

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,6 +830,7 @@ _Data flow / data management / data stores / components state / data flow_
 - [react-formawesome](https://github.com/MAKARD/react-formawesome) - Complex library for creating awesome forms.
 - [surveyjs](https://github.com/surveyjs/survey-library) - The advanced Survey and Form library
 - [Formily](https://github.com/alibaba/formily) - High performance, extensible, and Typescript friendly
+- [hook-form-react](https://github.com/luoanb/hook-form-react) - [docs](https://luoanb.github.io/hook-form-react) - A lightweight, dependency-free solution React hooks for form validation.
 
 ### Router
 


### PR DESCRIPTION

I've developed a form validation hook that enables quick integration with UI libraries (already compatible with Next UI, with support for other mainstream libraries in progress, a task that third parties can also undertake for swift adaptation). It offers open-ended interfaces, allowing users to freely manage form data and error messages (including server-returned validation feedback). The definition of validation rules is also open-ended, enabling users to extend them as per their business requirements.