### PR TITLE
add simpleParallax library

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ _Animate transitions_
 
 ### Parallax
 
-- [simple-parallax-js](https://github.com/geosigno/simpleParallax.js) - The easiest way to get a parallax effect with React and JavaScript on images
+- [simple-parallax-js](https://github.com/geosigno/simpleParallax.js) - [demo](https://simpleparallax.com) - The easiest way to get a parallax effect with React and JavaScript on images
 - [react-parallax-tilt](https://github.com/mkosir/react-parallax-tilt) - [demo](https://mkosir.github.io/react-parallax-tilt) - Easily apply parallax tilt hover effect on components.
 
 ## UI Frameworks

--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ _Animate transitions_
 
 ### Parallax
 
-- [react-parallax-component](https://github.com/keske/react-parallax-component) - Easiest way to add scroll parallax effect on the component.
+- [simple-parallax-js](https://github.com/geosigno/simpleParallax.js) - The easiest way to get a parallax effect with React and JavaScript on images
 - [react-parallax-tilt](https://github.com/mkosir/react-parallax-tilt) - [demo](https://mkosir.github.io/react-parallax-tilt) - Easily apply parallax tilt hover effect on components.
 
 ## UI Frameworks


### PR DESCRIPTION
I am adding simpleParallax that just released the version 6.0.0 with a react version, and remove a library that hasn't been updated since 7 years ago.