### PR TITLE
Add react-call: ⚛️ 📡 Call your React components

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,6 +917,7 @@ _Scaffold / starter kit / Yeoman generator / stack ensemble / seed_
 
 - [react-inlinesvg](https://github.com/matthewwithanm/react-inlinesvg) - An SVG loader component for ReactJS.
 - [react-godfather](https://github.com/kapolos/react-godfather) - A new way to write Functional Components, without Hooks.
+- [react-call](https://github.com/desko27/react-call) - Call your React components.
 - [redux-auth-patch](https://github.com/lynndylanhurley/redux-auth) - Complete token authentication system for react + redux that supports isomorphic rendering.
 - [redux-search](https://github.com/treasure-data/redux-search) - Redux bindings for client-side search.
 - [tcomb-react](https://github.com/gcanti/tcomb-react) - Alternative syntax for PropTypes.


### PR DESCRIPTION
- [x] Add [react-call](https://github.com/desko27/react-call) to `Code Design` > `Miscellaneous`.

# Features

Bring your React component, `react-call` gives you the `call(<props>)` method.

- 🔰 Easy to use
- ⛑️ Fully Type-Safe
- ⚡️ Causes no renders at all
- 🛜 Setup once, call from anywhere
- ⛓️‍💥 Not limited by a context provider
- 🤯 Call from outside React
- 🌀 Flexible: it's your component
- 📦 Extremely lightweight: <500B
- 🕳️ Zero dependencies

[See the rest of the readme](https://github.com/desko27/react-call)