### PR TITLE
add @classmatejs/react

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,6 +875,7 @@ _Component properties asynchronously fetched over the network_
 - [aesthetic](https://github.com/milesj/aesthetic) - A powerful type-safe, framework agnostic, CSS-in-JS library for styling components, whether it be plain objects, importing stylesheets, or simply referencing external class names.
 - [aphrodite](https://github.com/Khan/aphrodite) - It&#39;s inline styles, but they work!.
 - [inline-style-prefixer](https://github.com/rofrischmann/inline-style-prefixer) - Run-time Autoprefixer for Inline Style Objects.
+- [react-classmate](https://github.com/richard-unterberg/react-classmate) - A class name focused component builder with a syntax like styled components and the sugar of variants.
 - [react-container-query](https://github.com/d6u/react-container-query) - Modular responsive component.
 - [react-responsive](https://github.com/contra/react-responsive) - Media queries in react for responsive design.
 - [reactponsive](https://github.com/jmlweb/reactponsive) - Responsive components and hooks.


### PR DESCRIPTION
Hey Rom, good to see you again.

this one is fresh of the shelf and was one of the ideas rolling back and forth in my head for months. It's like styled components for the class name heavy websites of today, often archived with tailwind or unocss. It opens up a different path to maintain component classnames vertically and decoupled from the rest of the js(x). Recently I added the possibility to add variants, with them you can output a set of classnames related to a specific state, defined in one spot. This makes it easy to maintain components with a lot of describtive class names. Ships with typescript support and frequent updates.

Let me know if this is fitting your collection of awesome tools.
Cheers