### PR TITLE
Add Hugeicons and remove outdated iconify-react

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,12 +369,12 @@ _Display images / photos_
 
 _Display icons / icon set / emojis_
 
-- [iconify-react](https://github.com/iconify/iconify-react) - Over 40k icons from 50+ icon sets, including all popular icon and emoji sets.
+- [hugeicons](https://github.com/hugeicons/react) - Beautiful, production-ready icons with 46,000+ icons in 10 styles, including 4,600+ free open-source icons.
+- [Lucide](https://github.com/lucide-icons/lucide) - Beautiful & consistent icon toolkit made by the community. Open-source project and a fork of Feather Icons.
+- [react-icomoon](https://github.com/aykutkardas/react-icomoon) - With react-icomoon you can easily use the icons you have selected or created in icomoon.
 - [react-icons](https://github.com/gorangajic/react-icons) - Svg react icons of popular icon packs using ES6 imports.
 - [react-open-doodles](https://github.com/lunahq/react-open-doodles) - Awesome free illustrations as react components.
-- [react-icomoon](https://github.com/aykutkardas/react-icomoon) - With react-icomoon you can easily use the icons you have selected or created in icomoon.
 - [tabler-icons-react](https://tabler-icons-react.vercel.app) - A set of over 450 free MIT-licensed high-quality SVG icons.
-- [Lucide](https://github.com/lucide-icons/lucide) - Beautiful & consistent icon toolkit made by the community. Open-source project and a fork of Feather Icons.
 
 ### Paginator
 


### PR DESCRIPTION
### Add Hugeicons to Icons section                                                          
                                                                                          
 Per CONTRIBUTING, I removed a non-awesome/abandoned entry to keep the list fresh.       
                                                                                          
  Adds: Hugeicons to "Icons"                                                              
  - Beautiful, production-ready icons with 46,000+ icons in 10 styles                     
  - Includes 4,600+ free open-source icons in stroke-rounded style                        
  - Also available for React Native, Vue, Svelte, and Angular                             
  - Site: https://hugeicons.com/                                                          
  - Repo: https://github.com/hugeicons/react                                              
                                                                                          
  Removes: iconify-react (abandoned)                                                      
  - iconify-react hasn't been updated since February 2021 (almost 5 years without         
  maintenance).                                                                           
    Source: https://github.com/iconify/iconify-react (last commit: 2021-02-08)