### PR TITLE
Add react-tree-grid to Table section

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Please review our [contributing guidelines](https://github.com/brillout/awesome-
 - [DevExtreme React Grid](https://devexpress.github.io/devextreme-reactive/react/grid/) - High-performance plugin-based data grid for Bootstrap and Material Design.
 - [Smart React Grid](https://htmlelements.com/react/demos/grid/overview/) - Fast and feature-complete data grid with Material Design.
 - [simple-table](https://github.com/petera2c/simple-table) - [demo](https://www.simple-table.com/examples) - [docs](https://www.simple-table.com/docs) - Lightweight, fast and feature rich. Sorting/filtering, virtualization, tree data, nested headers, pinned columns, customized styling etc.
+- [react-tree-grid](https://github.com/itsmemyk/react-tree-grid) - [demo/docs](https://itsmemyk.github.io/react-tree-grid/) - High-performance Grid, Tree, and TreeGrid for React with sorting, grouping, drag-to-group, virtualization, and frozen columns
 
 - [KendoReact Grid](https://www.telerik.com/kendo-react-ui/components/grid/) - Powerful data grid component with 100+ ready-to-use features like paging, sorting, export to Excel, and more.
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ Please review our [contributing guidelines](https://github.com/brillout/awesome-
 
 - [ka-table](https://github.com/komarovalexander/ka-table) - [demo](https://komarovalexander.github.io/ka-table/#/overview) - Customizable table component with sorting, filtering, grouping, virtualization, editing etc.
 - [mantine-datatable](https://github.com/icflorescu/mantine-datatable) - [demo/docs](https://icflorescu.github.io/mantine-datatable/) - Lightweight table component for Mantine UI applications, with lots of features
-- [material-table](https://github.com/mbrn/material-table) - [demo/docs](https://material-table.com/) - Built on Material UI, plus: grouping, tree data, expandable rows, export, inline editing
 - [mui-datatables](https://github.com/gregnb/mui-datatables) - Built on Material UI. Search, styling, filtering, resize/hide columns, export, print, select/expand rows.
 - [react-data-table](https://github.com/jbetancur/react-data-table-component) - [demo/docs](https://jbetancur.github.io/react-data-table-component/?) - accessible, responsive, themable, declaratively configurable table with sorting, selectable rows, expandable rows, pagination
 - [TanStack Table](https://github.com/tannerlinsley/react-table) - [demo](https://tanstack.com/table/v8/docs/examples/react/basic) - Headless UI for building powerful tables & datagrids


### PR DESCRIPTION
## Add
  - [react-tree-grid](https://github.com/itsmemyk/react-tree-grid) — High-performance Grid, Tree, and TreeGrid for React with sorting, grouping, drag-to-group,
  virtualization, and frozen columns.
  
  ## Remove
  - `material-table` — last release was August 2020 (v1.69.0), no activity since. Effectively abandoned.