### PR TITLE
Add Bestax and create-bestax; remove two dead entries Body:

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ _Set of components + responsive layout system_
 - [ant-design](https://github.com/ant-design/ant-design) - [demo/docs](https://ant.design/docs/react/introduce) - A UI Design Language from China. Individual [components](http://react-component.github.io/) available.
 - [atlaskit](https://atlaskit.atlassian.com/packages) - Atlassian's official UI library, with components from _badge_ to _tree table_.
 - [base web](https://baseweb.design) - Base Web is a foundation for initiating, evolving, and unifying web products.
+- [Bestax](https://github.com/allxsmith/bestax) - [demo/docs](https://bestax.io) - Full-featured component library for Bulma, built for AI-powered development.
 - [carbon](https://github.com/carbon-design-system/carbon) - [demo/docs](https://www.carbondesignsystem.com/) - A design system built by IBM.
 - [cdbreact](https://github.com/Devwares-Team/cdbreact) - [demo](https://www.devwares.com/product/contrast) - [docs](https://www.devwares.com/docs/contrast/react/index) - Elegant UI Kit library and reusable components for building mobile-first, responsive websites and web apps.
 - [chakra-ui](https://github.com/chakra-ui/chakra-ui) - [demo/docs](https://chakra-ui.com) - Simple, Modular & Accessible UI Components for your React Applications.
@@ -695,7 +696,6 @@ _Set of components + responsive layout system_
 - [primereact](https://github.com/primefaces/primereact) - A complete UI Framework with 50+ components featuring material, bootstrap and custom themes.
 - [radix-ui](https://www.radix-ui.com/) - Unstyled, accessible components for building high‑quality design systems and web apps.
 - [react-bootstrap](https://github.com/react-bootstrap/react-bootstrap) - Bootstrap components built with React.
-- [react-foundation](https://github.com/digiaonline/react-foundation) - Foundation as React components.
 - [reakit](https://github.com/ariakit/ariakit) - [demo/docs](https://reakit.io/docs/button/) Toolkit for building accessible rich web apps
 - [searchkit](https://github.com/searchkit/searchkit) - React UI components / widgets. The easiest way to build a great search experience with Elasticsearch.
 - [semantic-ui-react](https://github.com/Semantic-Org/Semantic-UI-React) - The official Semantic-UI-React integration.
@@ -904,6 +904,7 @@ _Component properties asynchronously fetched over the network_
 
 _Scaffold / starter kit / Yeoman generator / stack ensemble / seed_
 
+- [create-bestax](https://github.com/allxsmith/bestax/tree/main/create-bestax) - Scaffolds a Bulma + Bestax project, built for AI-powered development.
 - [create-react-app](https://github.com/facebookincubator/create-react-app) - Create React apps with no build configuration.
 - [crisp-react](https://github.com/winwiz1/crisp-react) - Express integration in TypeScript with support for multiple SPAs and pitfall avoidance.
 - [cra-template-redux-auth-starter](https://github.com/Nilanth/cra-template-redux-auth-starter) - A Redux auth starter boilerplate for CRA.
@@ -914,7 +915,6 @@ _Scaffold / starter kit / Yeoman generator / stack ensemble / seed_
 - [nwb](https://github.com/insin/nwb) - CLI tool and devDependency for React apps &amp; components and npm modules.
 - [nx](https://nx.dev) - Next generation build system with first class monorepo support and powerful integrations.
 - [PBandJ](https://github.com/moishinetzer/pbandj) - Zero-Config Reusable Component Framework.
-- [react-hot-boilerplate](https://github.com/gaearon/react-hot-boilerplate) - Minimal live-editing boilerplate for your next ReactJS project.
 - [rockpack](https://github.com/AlexSergey/rockpack) - Simple solution for creating React application with SSR, bundling, linting, testing within 5 minutes.
 - [create-react-dependency](https://github.com/andrelmlins/create-react-dependency) - Create react dependencies with no build configuration.
 - [phoenix](https://github.com/Sazito/phoenix) - A simple boilerplate that helps you make your react application with Server Side Rendering & Localization support.


### PR DESCRIPTION
**Added:**

- **UI Frameworks → Responsive:** [Bestax](https://github.com/allxsmith/bestax) ([demo/docs](https://bestax.io)) - full-featured component library for Bulma, built for AI-powered development. Actively developed, fully typed, with per-component docs and Storybook coverage.
- **Code Design → Boilerplate:** [create-bestax](https://github.com/allxsmith/bestax/tree/main/create-bestax) - scaffolds a Bulma + Bestax project, built for AI-powered development.

**Removed (per the "remove one or more non-awesome entries" rule):**

- `react-foundation` - archived by its owner on Mar 7, 2023 (read-only); last release 2021.
- `react-hot-boilerplate` - deprecated; its README says to use react-refresh-webpack-plugin instead.